### PR TITLE
fix byteorder version, bump tinyosc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyosc"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["William Light <wrl@illest.net>"]
 description = "OpenSoundControl implementation"
 license = "MIT"
@@ -9,4 +9,4 @@ keywords = ["audio", "osc", "opensoundcontrol"]
 repository = "https://github.com/wrl/tinyosc"
 
 [dependencies]
-byteorder = "*"
+byteorder = "0.4.2"


### PR DESCRIPTION
changes in the byteorder lib have broken tinyosc!  putting in the version number fixes the problem.  Also bumping the tinyosc version number.  
