### PR TITLE
pattern matching via regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/wrl/tinyosc"
 
 [dependencies]
 byteorder = "0.5.1"
-regex = "*"
+regex = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/wrl/tinyosc"
 
 [dependencies]
 byteorder = "0.5.1"
+regex = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,15 @@
 // SOFTWARE.
 
 extern crate byteorder;
+extern crate regex;
 
 mod message;
 mod argument;
+mod pattern;
 
 pub use message::Message;
 pub use argument::Argument;
+pub use pattern::Pattern;
 
 #[macro_export]
 macro_rules! osc_args {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -33,6 +33,10 @@ pub struct Pattern {
 
 impl Pattern {
     pub fn new(pattern: &str) -> Result<Pattern, ()> {
+        if !pattern.starts_with('/') {
+            return Err(())
+        }
+
         let mut pattern_re = String::new();
 
         let chars = pattern.chars().collect::<Vec<char>>();
@@ -62,6 +66,9 @@ impl Pattern {
                     pattern_re.push_str(OSC_ADDR_SYMBOL);
                     pattern_re.push('*');
                 }
+                ']' => {
+                    return Err(())
+                }
                 '[' => {
                     let j = pattern.find(']').unwrap();
 
@@ -83,6 +90,9 @@ impl Pattern {
 
                     pattern_re.push_str("]");
                     i = j;
+                }
+                '}' => {
+                    return Err(())
                 }
                 '{' => {
                     let j = pattern.find('}').unwrap();

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -105,11 +105,12 @@ impl Pattern {
         pattern_re.insert(0, '^');
         pattern_re.push('$');
 
-        Ok(
-        Pattern {
-            pattern_re: Regex::new(pattern_re.as_str()).unwrap()
+        match Regex::new(pattern_re.as_str()) {
+            Ok(re) => Ok(Pattern {
+                pattern_re: re
+            }),
+            Err(_) => Err(())
         }
-        )
     }
 
     pub fn matches(&self, m: Message) -> bool {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -101,6 +101,9 @@ impl Pattern {
             i += 1;
         }
 
+        pattern_re.insert(0, '^');
+        pattern_re.push('$');
+
         Ok(
         Pattern {
             pattern_re: Regex::new(pattern_re.as_str()).unwrap()

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -38,7 +38,7 @@ impl Pattern {
         let chars = pattern.chars().collect::<Vec<char>>();
         let mut i = 0;
 
-        while i < chars.len() {
+        while i < pattern.len() {
             let c = chars[i];
 
             assert!(c.is_ascii());
@@ -46,7 +46,8 @@ impl Pattern {
             match c {
                 '/' => {
                     let j = i + 1;
-                    if chars[j] == '/' {
+
+                    if j < pattern.len() && chars[j] == '/' {
                         pattern_re.push_str(OSC_ADDR_FULL);
                         pattern_re.push_str("*/");
                         i = j;

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2015 William Light <wrl@illest.net>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::ascii::AsciiExt;
+use regex;
+use regex::Regex;
+use Message;
+
+// all printable ascii characters except #*,/?[]{} and space
+const OSC_ADDR_SYMBOL: &'static str = r#"[A-Za-z0-9!"$%&'()+.0-9:;<=>@\\^_`|~-]"#;
+const OSC_ADDR_FULL:   &'static str = r#"[A-Za-z0-9!"$%&'()+.0-9:;<=>@\\^_`|~/-]"#;
+
+pub struct Pattern {
+    pattern_re: Regex
+}
+
+impl Pattern {
+    pub fn new(pattern: &str) -> Result<Pattern, ()> {
+        let mut pattern_re = String::new();
+
+        let chars = pattern.chars().collect::<Vec<char>>();
+        let mut i = 0;
+
+        while i < chars.len() {
+            let c = chars[i];
+
+            assert!(c.is_ascii());
+
+            match c {
+                '/' => {
+                    let j = i + 1;
+                    if chars[j] == '/' {
+                        pattern_re.push_str(OSC_ADDR_FULL);
+                        pattern_re.push_str("*/");
+                        i = j;
+                    } else {
+                        pattern_re.push_str(regex::escape(c.to_string().as_str()).as_str());
+                    }
+                }
+                '?' => {
+                    pattern_re.push_str(OSC_ADDR_SYMBOL);
+                }
+                '*' => {
+                    pattern_re.push_str(OSC_ADDR_SYMBOL);
+                    pattern_re.push('*');
+                }
+                '[' => {
+                    let j = pattern.find(']').unwrap();
+
+                    pattern_re.push_str("[");
+                    let mut sub = &pattern[i+1..j];
+
+                    if sub.starts_with("!") {
+                        sub = &sub[1..];
+                        pattern_re.push_str("^");
+                    }
+
+                    for (ci, c) in sub.char_indices() {
+                        if c == '-' && ci != sub.len() {
+                            pattern_re.push_str("-");
+                        } else {
+                            pattern_re.push_str(regex::escape(c.to_string().as_str()).as_str());
+                        }
+                    }
+
+                    pattern_re.push_str("]");
+                    i = j;
+                }
+                '{' => {
+                    let j = pattern.find('}').unwrap();
+                    pattern_re.push_str("(");
+
+                    let sub = &pattern[i+1..j];
+                    let s = sub.split(',').collect::<Vec<&str>>().join("|");
+                    pattern_re.push_str(s.as_str());
+                    
+                    pattern_re.push_str(")");
+                    i = j;
+                }
+                _ => {
+                    pattern_re.push_str(regex::escape(c.to_string().as_str()).as_str());
+                }
+            }
+            i += 1;
+        }
+
+        Ok(
+        Pattern {
+            pattern_re: Regex::new(pattern_re.as_str()).unwrap()
+        }
+        )
+    }
+
+    pub fn matches(&self, m: Message) -> bool {
+        return self.pattern_re.is_match(m.path);
+    }
+
+    pub fn matches_path(&self, path: &str) -> bool {
+        return self.pattern_re.is_match(path);
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,7 +21,8 @@
 #[allow(unused_imports)]
 use {
     Argument,
-    Message
+    Message,
+    Pattern
 };
 
 macro_rules! assert_msg_equal {
@@ -221,4 +222,16 @@ fn deserialize_kitchen_sink() {
         Argument::F => true,
         _ => false
     });
+}
+
+#[test]
+fn pattern_match_exact() {
+    let pat = Pattern::new("/hello").unwrap();
+    assert!(pat.matches_path("/hello"));
+}
+
+#[test]
+fn pattern_match_any() {
+    let pat = Pattern::new("/hello*").unwrap();
+    assert!(!pat.matches_path("/test_msg"));
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -225,13 +225,112 @@ fn deserialize_kitchen_sink() {
 }
 
 #[test]
+fn pattern_create() {
+    let pat = Pattern::new("/hello");
+    assert!(pat.is_ok());
+    let pat = Pattern::new("");
+    assert!(!pat.is_ok());
+    let pat = Pattern::new("/hello[something");
+    assert!(!pat.is_ok());
+    let pat = Pattern::new("/hello]");
+    assert!(!pat.is_ok());
+    let pat = Pattern::new("/hello{something");
+    assert!(!pat.is_ok());
+    let pat = Pattern::new("/hello}");
+    assert!(!pat.is_ok());
+}
+
+#[test]
 fn pattern_match_exact() {
     let pat = Pattern::new("/hello").unwrap();
     assert!(pat.matches_path("/hello"));
+    assert!(!pat.matches_path("/hello2"));
+    assert!(!pat.matches_path("/test_msg"));
+}
+
+#[test]
+fn pattern_match_asterisk_end() {
+    let pat = Pattern::new("/hello*").unwrap();
+    assert!(pat.matches_path("/hello"));
+    assert!(pat.matches_path("/hello2"));
+    assert!(!pat.matches_path("/test_msg"));
+}
+
+#[test]
+fn pattern_match_asterisk_start() {
+    let pat = Pattern::new("/*world").unwrap();
+    assert!(pat.matches_path("/world"));
+    assert!(pat.matches_path("/helloworld"));
+    assert!(!pat.matches_path("/test_msg"));
+}
+
+#[test]
+fn pattern_match_asterisk_middle() {
+    let pat = Pattern::new("/goodbye*world").unwrap();
+    assert!(pat.matches_path("/goodbyeworld"));
+    assert!(pat.matches_path("/goodbye_cruel_world"));
+    assert!(!pat.matches_path("/test_msg"));
+}
+
+#[test]
+fn pattern_match_question_mark() {
+    let pat = Pattern::new("/hell?").unwrap();
+    assert!(pat.matches_path("/hello"));
+    assert!(!pat.matches_path("/hello_"));
+}
+
+#[test]
+fn pattern_match_curly_braces() {
+    let pat = Pattern::new("/hello/{world,roger}").unwrap();
+    assert!(pat.matches_path("/hello/world"));
+    assert!(pat.matches_path("/hello/roger"));
+    assert!(!pat.matches_path("/hello/sarah"));
+}
+
+#[test]
+fn pattern_match_square_brackets_positive() {
+    let pat = Pattern::new("/hello/[ab]x").unwrap();
+    assert!(pat.matches_path("/hello/ax"));
+    assert!(pat.matches_path("/hello/bx"));
+    assert!(!pat.matches_path("/hello/cx"));
+}
+
+#[test]
+fn pattern_match_square_brackets_negative() {
+    let pat = Pattern::new("/hello/[!ab]x").unwrap();
+    assert!(!pat.matches_path("/hello/ax"));
+    assert!(!pat.matches_path("/hello/bx"));
+    assert!(pat.matches_path("/hello/cx"));
+}
+
+#[test]
+fn pattern_match_square_brackets_set_positive() {
+    let pat = Pattern::new("/hello/[a-f]x").unwrap();
+    assert!(pat.matches_path("/hello/ax"));
+    assert!(pat.matches_path("/hello/bx"));
+    assert!(pat.matches_path("/hello/cx"));
+    assert!(!pat.matches_path("/hello/gx"));
+}
+
+#[test]
+fn pattern_match_square_brackets_set_negative() {
+    let pat = Pattern::new("/hello/[!a-f]x").unwrap();
+    assert!(!pat.matches_path("/hello/ax"));
+    assert!(!pat.matches_path("/hello/bx"));
+    assert!(!pat.matches_path("/hello/cx"));
+    assert!(pat.matches_path("/hello/gx"));
+}
+
+#[test]
+fn pattern_match_double_slash() {
+    let pat = Pattern::new("/hello//world").unwrap();
+    assert!(pat.matches_path("/hello/world"));
+    assert!(pat.matches_path("/hello/brave/new/world"));
 }
 
 #[test]
 fn pattern_match_any() {
-    let pat = Pattern::new("/hello*").unwrap();
-    assert!(!pat.matches_path("/test_msg"));
+    let pat = Pattern::new("//*").unwrap();
+    assert!(pat.matches_path("/x"));
+    assert!(pat.matches_path("/hello/world"));
 }


### PR DESCRIPTION
basic pattern matching. this implementation translates osc address patterns to regular expressions and provides a method for matching messages against the latter.